### PR TITLE
Adds tags to each tab view to keep track of the selected view

### DIFF
--- a/Learning/Learning/ContentView.swift
+++ b/Learning/Learning/ContentView.swift
@@ -8,21 +8,26 @@
 import SwiftUI
 
 struct ContentView: View {
+  @SceneStorage("selectedView") var selectedView: String?
+
   var body: some View {
-    TabView {
+    TabView(selection: $selectedView) {
       HomeView()
+        .tag(HomeView.tag)
         .tabItem {
           Image(systemName: "house")
           Text("Home")
         }
       
       ProjectsView(showClosedProjects: false)
+        .tag(ProjectsView.closedTag)
         .tabItem {
           Image(systemName: "list.bullet")
           Text("Open")
         }
       
       ProjectsView(showClosedProjects: true)
+        .tag(ProjectsView.openTag)
         .tabItem {
           Image(systemName: "checkmark")
           Text("Closed")

--- a/Learning/Learning/HomeView.swift
+++ b/Learning/Learning/HomeView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct HomeView: View {
+  static let tag: String? = "Home"
+  
   @EnvironmentObject var dataController: DataController
   
   var body: some View {

--- a/Learning/Learning/ProjectsView.swift
+++ b/Learning/Learning/ProjectsView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct ProjectsView: View {
+  static let openTag: String? = "Open"
+  static let closedTag: String? = "Closed"
+  
   let showClosedProjects: Bool
   
   let projects: FetchRequest<Project>


### PR DESCRIPTION
Learned about @AppStorage and @SceneStorage.  

For this use case SceneStorage is better, when the user terminates the application with AppStorage the selected tab would still persist, whereas scenestorage will be reset.

Also, learned that we need to set the tag as an optional string in order for the @SceneStorage to match (since it stores an optional string).

Optional strings are really Optional<String> afterall.