### PR TITLE
Feature/08 save to core data

### DIFF
--- a/Learning/Learning.xcodeproj/project.pbxproj
+++ b/Learning/Learning.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		121C0CDA25C1EA6000B9C2F3 /* EditItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121C0CD925C1EA6000B9C2F3 /* EditItemView.swift */; };
 		121C0CDD25C1EF3700B9C2F3 /* ItemRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121C0CDC25C1EF3700B9C2F3 /* ItemRowView.swift */; };
+		121C0CE125C1F3CB00B9C2F3 /* Binding-OnChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121C0CE025C1F3CB00B9C2F3 /* Binding-OnChange.swift */; };
 		1228938725B841640011DD1B /* LearningApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1228938625B841640011DD1B /* LearningApp.swift */; };
 		1228938925B841640011DD1B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1228938825B841640011DD1B /* ContentView.swift */; };
 		1228938B25B841650011DD1B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1228938A25B841650011DD1B /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 /* Begin PBXFileReference section */
 		121C0CD925C1EA6000B9C2F3 /* EditItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditItemView.swift; sourceTree = "<group>"; };
 		121C0CDC25C1EF3700B9C2F3 /* ItemRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRowView.swift; sourceTree = "<group>"; };
+		121C0CE025C1F3CB00B9C2F3 /* Binding-OnChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Binding-OnChange.swift"; sourceTree = "<group>"; };
 		1228938325B841640011DD1B /* Learning.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Learning.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1228938625B841640011DD1B /* LearningApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningApp.swift; sourceTree = "<group>"; };
 		1228938825B841640011DD1B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				121C0CD925C1EA6000B9C2F3 /* EditItemView.swift */,
 				1257FC6425C1623F00D6A165 /* Item-CoreDataHelpers.swift */,
 				1257FC6725C1624F00D6A165 /* Project-CoreDataHelpers.swift */,
+				121C0CE025C1F3CB00B9C2F3 /* Binding-OnChange.swift */,
 			);
 			path = Learning;
 			sourceTree = "<group>";
@@ -182,6 +185,7 @@
 				1228939B25B844DF0011DD1B /* DataController.swift in Sources */,
 				121C0CDD25C1EF3700B9C2F3 /* ItemRowView.swift in Sources */,
 				1228938925B841640011DD1B /* ContentView.swift in Sources */,
+				121C0CE125C1F3CB00B9C2F3 /* Binding-OnChange.swift in Sources */,
 				1257FC5225C0B0F100D6A165 /* HomeView.swift in Sources */,
 				1228938725B841640011DD1B /* LearningApp.swift in Sources */,
 				1257FC6525C1623F00D6A165 /* Item-CoreDataHelpers.swift in Sources */,

--- a/Learning/Learning/Binding-OnChange.swift
+++ b/Learning/Learning/Binding-OnChange.swift
@@ -1,0 +1,20 @@
+//
+//  Binding-OnChange.swift
+//  Learning
+//
+//  Created by Dan Smith on 27/01/2021.
+//
+
+import SwiftUI
+
+extension Binding {
+  func onChange(_ handler: @escaping () -> Void)  -> Binding<Value> {
+    Binding(
+      get: { self.wrappedValue },
+      set: { newValue in
+        self.wrappedValue = newValue
+        handler()
+      }
+    )
+  }
+}

--- a/Learning/Learning/EditItemView.swift
+++ b/Learning/Learning/EditItemView.swift
@@ -47,6 +47,7 @@ struct EditItemView: View {
       }
     }
     .navigationTitle("Edit Item")
+    .onDisappear(perform: dataController.save)
   }
 
   func update() {

--- a/Learning/Learning/EditItemView.swift
+++ b/Learning/Learning/EditItemView.swift
@@ -29,12 +29,12 @@ struct EditItemView: View {
   var body: some View {
     Form {
       Section(header: Text("Basic settings")) {
-        TextField("Item name", text: $title)
-        TextField("Descriptioon", text: $detail)
+        TextField("Item name", text: $title.onChange(update))
+        TextField("Descriptioon", text: $detail.onChange(update))
       }
 
       Section(header: Text("Priority")) {
-        Picker("Priority", selection: $priority) {
+        Picker("Priority", selection: $priority.onChange(update)) {
           Text("Low").tag(1)
           Text("Medium").tag(2)
           Text("High").tag(3)
@@ -43,15 +43,10 @@ struct EditItemView: View {
       }
 
       Section {
-        Toggle("Mark Completed", isOn: $completed)
+        Toggle("Mark Completed", isOn: $completed.onChange(update))
       }
     }
     .navigationTitle("Edit Item")
-    // SwiftUI way of updating before the view disappear
-    .onChange(of: title) { _ in update() }
-    .onChange(of: detail) { _ in update() }
-    .onChange(of: priority) { _ in update() }
-    .onChange(of: completed) { _ in update() }
   }
 
   func update() {

--- a/Learning/Learning/EditItemView.swift
+++ b/Learning/Learning/EditItemView.swift
@@ -47,7 +47,11 @@ struct EditItemView: View {
       }
     }
     .navigationTitle("Edit Item")
-    .onDisappear(perform: update)
+    // SwiftUI way of updating before the view disappear
+    .onChange(of: title) { _ in update() }
+    .onChange(of: detail) { _ in update() }
+    .onChange(of: priority) { _ in update() }
+    .onChange(of: completed) { _ in update() }
   }
 
   func update() {

--- a/Learning/Learning/LearningApp.swift
+++ b/Learning/Learning/LearningApp.swift
@@ -21,6 +21,11 @@ struct LearningApp: App {
       ContentView()
         .environment(\.managedObjectContext, dataController.container.viewContext)
         .environmentObject(dataController)
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification), perform: save)
     }
+  }
+
+  func save(_ notification: Notification) {
+    dataController.save()
   }
 }


### PR DESCRIPTION
Adds  updating ability for when items are edited.
Adds nifty extension to Binding that enables us to update SwiftUI list in oneline
Adds a call to `datacontroller.save` when the view will disappear
Adds call to `dataController.save` if the app recieves `willResignActiveNotification`